### PR TITLE
Replace deprecated TEMP_CELSIUS const by the new UnitOfTemperature.CELSIUS

### DIFF
--- a/custom_components/nhc2/coco_climate.py
+++ b/custom_components/nhc2/coco_climate.py
@@ -5,12 +5,15 @@ from .const import THERM_PROGRAM, THERM_OVERRULEACTION, THERM_OVERRULESETPOINT, 
 from .coco_entity import CoCoEntity
 
 from homeassistant.components.climate import (
-    TEMP_CELSIUS,
     SUPPORT_TARGET_TEMPERATURE,
     SUPPORT_TARGET_TEMPERATURE_RANGE,
     SUPPORT_PRESET_MODE, 
     HVAC_MODE_HEAT,
     HVAC_MODE_HEAT_COOL
+)
+
+from homeassistant.const import (
+    UnitOfTemperature
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -23,7 +26,7 @@ class CoCoThermostat(CoCoEntity):
 
     @property
     def temperature_unit(self):
-        return TEMP_CELSIUS
+        return UnitOfTemperature.CELSIUS
 
     @property
     def target_temperature_low(self):


### PR DESCRIPTION
TEMP_CELSIUS const doesn't work anymore in HA 2023.1.0, replace it by the new UnitOfTemperature.CELSIUS 